### PR TITLE
Refactor make-release workflow to include subject in merge command

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -90,7 +90,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - run: gh pr merge --merge --delete-branch
+    - run: gh pr merge --merge --delete-branch --subject "Release ${{ steps.increment-version.outputs.version }}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Update the make-release workflow to include the `--subject` flag in the `gh pr merge` command
- The subject is set to "Release ${{ steps.increment-version.outputs.version }}"
